### PR TITLE
Added the start of support for WASM/WASI

### DIFF
--- a/projects/rpassword/src/rpassword/all.rs
+++ b/projects/rpassword/src/rpassword/all.rs
@@ -3,7 +3,30 @@ use crate::rutil::print_tty::{print_tty, print_writer};
 use crate::rutil::safe_string::SafeString;
 use std::io::{BufRead, Write};
 
-#[cfg(unix)]
+#[cfg(target_family = "wasm")]
+mod wasm {
+    use std::io::{self, BufRead};
+
+    /// Reads a password from the TTY
+    pub fn read_password() -> std::io::Result<String> {
+        let tty = std::fs::File::open("/dev/tty")?;
+        let mut reader = io::BufReader::new(tty);
+
+        read_password_from_fd_with_hidden_input(&mut reader)
+    }
+
+    /// Reads a password from a given file descriptor
+    fn read_password_from_fd_with_hidden_input(
+        reader: &mut impl BufRead,
+    ) -> std::io::Result<String> {
+        let mut password = super::SafeString::new();
+
+        reader.read_line(&mut password)?;
+        super::fix_new_line(password.into_inner())
+    }
+}
+
+#[cfg(target_family = "unix")]
 mod unix {
     use libc::{c_int, tcsetattr, termios, ECHO, ECHONL, TCSANOW};
     use std::io::{self, BufRead};
@@ -85,7 +108,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::{self, BufReader};
     use std::io::{BufRead, StdinLock};
@@ -176,9 +199,11 @@ mod windows {
     }
 }
 
-#[cfg(unix)]
+#[cfg(target_family = "wasm")]
+pub use wasm::read_password;
+#[cfg(target_family = "unix")]
 pub use unix::read_password;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::read_password;
 
 /// Reads a password from anything that implements BufRead

--- a/projects/rutil/src/rutil/atty.rs
+++ b/projects/rutil/src/rutil/atty.rs
@@ -27,7 +27,7 @@ pub enum Stream {
 }
 
 /// returns true if this is a tty
-#[cfg(all(unix, not(target_arch = "wasm32")))]
+#[cfg(target_family = "unix")]
 pub fn is(stream: Stream) -> bool {
     let fd = match stream {
         Stream::Stdout => libc::STDOUT_FILENO,
@@ -141,7 +141,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(target_arch = "wasm32")]
+#[cfg(target_family = "wasm")]
 pub fn is(_stream: Stream) -> bool {
     false
 }

--- a/projects/rutil/src/rutil/print_tty.rs
+++ b/projects/rutil/src/rutil/print_tty.rs
@@ -1,4 +1,18 @@
-#[cfg(unix)]
+#[cfg(target_family = "wasm")]
+mod wasm {
+    use std::io::Write;
+
+    /// Displays a message on the STDOUT
+    pub fn print_tty(prompt: impl ToString) -> std::io::Result<()> {
+        let mut stdout = std::io::stdout();
+        write!(stdout, "{}", prompt.to_string().as_str())?;
+        stdout.flush()?;
+        Ok(())
+    }
+}
+
+
+#[cfg(target_family = "unix")]
 mod unix {
     use std::io::Write;
 
@@ -11,7 +25,7 @@ mod unix {
     }
 }
 
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 mod windows {
     use std::io::Write;
     use std::os::windows::io::FromRawHandle;
@@ -52,7 +66,9 @@ pub fn print_writer(stream: &mut impl Write, prompt: impl ToString) -> std::io::
 }
 
 use std::io::Write;
-#[cfg(unix)]
+#[cfg(target_family = "unix")]
 pub use unix::print_tty;
-#[cfg(windows)]
+#[cfg(target_family = "windows")]
 pub use windows::print_tty;
+#[cfg(target_family = "wasm")]
+pub use wasm::print_tty;


### PR DESCRIPTION
Its only the start but the idea is to make it work with WebAssembly shell:
https://webassembly.sh/

Which I had to copy and fix because of more restrictions in browsers these days
https://www.tokera.com/sh

The main bit thats missing is that WASI does not expose TTY syscalls yet so we need those in order to hide the STDOUT echo.

Tested on:
unix
--target wasm32-unknown-emscripten
--target wasm32-wasi