### PR TITLE
Remove serde dependencies from rpassword

### DIFF
--- a/projects/rpassword/Cargo.toml
+++ b/projects/rpassword/Cargo.toml
@@ -11,6 +11,11 @@ readme = "README.md"
 keywords = ["read", "password", "security", "pass", "getpass"]
 edition = "2018"
 
+[features]
+# Do not use this. Exists only to workaround the `duck` monorepo's structure.
+# It is not covered by any semver versioning.
+__serde = []
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
@@ -18,5 +23,3 @@ libc = "0.2"
 winapi = { version = "0.3", features = ["std", "winnt", "fileapi", "processenv", "winbase", "handleapi", "consoleapi", "minwindef", "wincon"] }
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"

--- a/projects/rutil/src/rutil.rs
+++ b/projects/rutil/src/rutil.rs
@@ -2,5 +2,6 @@ pub mod atty;
 pub mod fix_new_line;
 pub mod print_tty;
 pub mod safe_string;
+#[cfg(feature = "__serde")]
 pub mod safe_string_serde;
 pub mod safe_vec;


### PR DESCRIPTION
Although I'm unsure of this approach, it does work for the `rpassword` crate. With these changes, a dummy consumer of `/duck/projects/rpassword` no longer has `serde` in the tree.

 What it broke I'm not sure of yet. I have a suspicion I'll need to tweak some other projects here too but was unable to find what used this code with a grep.

Re https://github.com/conradkleinespel/rpassword/issues/68