### PR TITLE
add MIT license to rtoolbox metadata

### DIFF
--- a/projects/rtoolbox/Cargo.toml
+++ b/projects/rtoolbox/Cargo.toml
@@ -3,7 +3,7 @@ name = "rtoolbox"
 version = "0.0.1"
 description = "Utility functions for other crates, no backwards compatibility guarantees."
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
-license = "Apache-2.0"
+license = "Apache-2.0 AND MIT"
 edition = "2018"
 
 [features]


### PR DESCRIPTION
The `atty.rs` file (copied from the old `atty` crate) is distributed under the terms of the MIT license. This needs to be reflected in crate metadata.

The MIT license also requires that a copy of the license text is included with distributed sources, but I'm not sure if the header in the `src/atty.rs` file is enough to satisfy this requirement.