### PR TITLE
Add repository link to rtoolbox

### DIFF
--- a/projects/rtoolbox/Cargo.toml
+++ b/projects/rtoolbox/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rtoolbox"
 version = "0.0.2"
 description = "Utility functions for other crates, no backwards compatibility guarantees."
+repository = "https://github.com/conradkleinespel/duck"
 authors = ["Conrad Kleinespel <conradk@conradk.com>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
I was looking for it, from docs.rs, yet couldn't find it due to this missing metadata.